### PR TITLE
4 parfile fix

### DIFF
--- a/neklab/examples/Newton-GMRES/1cyl.par
+++ b/neklab/examples/Newton-GMRES/1cyl.par
@@ -1,16 +1,22 @@
 [GENERAL]
+startFrom = 0
 stopAt = endtime
+#numSteps = 1000
 endTime = 1.0
 
 dt = 0.01
 variableDt = no
 timeStepper = bdf3
-targetCFL = 0.5
+targetCFL = 1.00000
 
 writeControl = runTime
-writeInterval = 100.
+writeInterval = 20
 writeDoublePrecision = no
+
 dealiasing = yes
+#filtering = explicit
+#filterWeight = 0.01
+#filterCutoffRatio = 0.84
 
 [PROBLEMTYPE]
 equation = incompNS
@@ -23,6 +29,6 @@ writeToFieldFile = yes
 
 [VELOCITY]
 residualTol = 1.0E-8
-residualProj = yes
+residualProj = no
 density = 1.0
 viscosity = -100.0

--- a/neklab/examples/README.md
+++ b/neklab/examples/README.md
@@ -22,6 +22,22 @@ To run the case:
 * generate the processor map file `1cyl.ma2` using the tool `genmap` distributed together with `Nek5000`.
 * run the code using the parallel executable provided in `Nek5000/bin/`.
 
+To run on 12 cores in the foreground with `nek5000` logfile output to stdout:
+```
+nekmpi 1cyl 12
+```
+To run on 12 cores in the background with `nek5000` logfile output to `logfile`:
+```
+nekbmpi 1cyl 12
+```
+The `nek5000` logfile contains runtime information for each timestep. The information about the progress of the algorithms from `LightKrylov` are output to `lightkrylov.log`.
+
+**Note**: The executable that is compiled with the default settings can only be run on 12 cores (or more) since the static array dimensions are chosen appropriately. To run on fewer cores, change the line
+```
+parameter (lpmin=12)              ! min number of MPI ranks
+```
+in the `SIZE` file and recompile.
+
 # Example list
 * `Newton-GMRES`: Newton-Krylov iteration to find the steady fixed-point of the nonlinear Navier-Stokes equations for the supercritical cylinder flow at Re=100.
 * `eigs`: Krylov-Schur eigenvalue iteration to find the leading eigenpair of the exponential propagator of the linearized Navier-Stokes operator around the steady fixed-point of the supercritical cylinder flow at Re=100. 

--- a/neklab/examples/eigs/1cyl.par
+++ b/neklab/examples/eigs/1cyl.par
@@ -1,19 +1,21 @@
 [GENERAL]
-stopAt = endTime
-numSteps = 1.0
+startFrom = 0
+stopAt = numSteps
+numSteps = 100
 
-dt = 0.01
+dt = 1.000000E-02
+timeStepper = bdf2
 variableDt = no
-timeStepper = bdf3
-targetCFL = 0.5
+targetCFL = 1.0000
 
 writeControl = runTime
 writeInterval = 100.
 writeDoublePrecision = no
-dealiasing = yes
 
-[PROBLEMTYPE]
-equation = incompLinNS
+dealiasing = yes
+#filtering = explicit
+#filterWeight = 0.01
+#filterCutoffRatio = 0.84
 
 [PRESSURE]
 preconditioner = semg_xxt
@@ -23,6 +25,6 @@ writeToFieldFile = yes
 
 [VELOCITY]
 residualTol = 1.0E-9
-residualProj = yes
+residualProj = no
 density = 1.0
 viscosity = -100.0


### PR DESCRIPTION
Bug fixes and improvements for the `neklab` examples for `LightKrylov':

- [x] Update the `1cyl.par` files to include all necessary runtime info.
- [x] Update the `README.md` to include the concrete commands to run nek in parallel (as required by the current compilation setup)

Closes #4 